### PR TITLE
Run updater.ps1 with -NoProfile switch

### DIFF
--- a/mpv-root/updater.bat
+++ b/mpv-root/updater.bat
@@ -5,4 +5,4 @@ if exist "%~dp0\installer\updater.ps1" (
 ) else (
     set updater_script="%~dp0\updater.ps1"
 )
-powershell -noexit -executionpolicy bypass -File %updater_script%
+powershell -noprofile -nologo -noexit -executionpolicy bypass -File %updater_script%


### PR DESCRIPTION
I have some scripts and functions in my PowerShell_profile.ps1 that I use for convenience purposes, and most importantly, I have this line:

Set-Location $HOME

So whenever I open a PowerShell console, it automatically sets my working directory to $HOME. Therefore, when I run updater.bat to update mpv, the update.ps1 script will check for the mpv binary in the wrong installation path. Adding -NoProfile to PowerShell arguments prevents that.