### PR TITLE
small enhancement to updater.bat

### DIFF
--- a/mpv-root/updater.bat
+++ b/mpv-root/updater.bat
@@ -12,6 +12,4 @@ powershell -noprofile -nologo -executionpolicy bypass -File %updater_script%
 if exist "%~dp0\installer\updater.ps1" if exist "%~dp0\updater.ps1" (
     del "%~dp0\updater.ps1"
 )
-echo press any key to EXIT
-pause >nul
-exit
+@pause

--- a/mpv-root/updater.bat
+++ b/mpv-root/updater.bat
@@ -6,9 +6,12 @@ if exist "%~dp0\installer\updater.ps1" (
 ) else (
     set updater_script="%~dp0\updater.ps1"
 )
-powershell -noprofile -nologo -noexit -executionpolicy bypass -File %updater_script%
+powershell -noprofile -nologo -executionpolicy bypass -File %updater_script%
 
 :: After update, updater.ps1 should not in same folder as mpv.exe
 if exist "%~dp0\installer\updater.ps1" if exist "%~dp0\updater.ps1" (
     del "%~dp0\updater.ps1"
 )
+echo press any key to EXIT
+pause >nul
+exit


### PR DESCRIPTION
**REASON FOR CHANGES:**
Every time when **"updater.bat"** finish updating,user(s) either have to type **exit** (to exit ) or close the cmd window manually.This change will keep the cmd window open(to be visible what's updated and what's not) and prompt user(s) to press **any key** to exit(terminate)
**CHANGES:**
Removed **-noexit** argument,added: **@pause** to the end of the batch.
**PERSONAL NOTE:**
Unless **-noexit** argument was implemented for a reason(for example user(s) to be able to enter other commands to the script) i believe the changes i've made it's the better alternative.
This should close #4 (either merged or not) 