### PR TITLE
Start menu shortcut

### DIFF
--- a/mpv-root/installer/mpv-install.bat
+++ b/mpv-root/installer/mpv-install.bat
@@ -174,7 +174,7 @@ call :add_type ""                                 "audio" "CUE Sheet"           
 :: Register "Default Programs" entry
 call :reg add "HKLM\SOFTWARE\RegisteredApplications" /v "mpv" /d "SOFTWARE\Clients\Media\mpv\Capabilities" /f
 
-:: Add mpv start menu shortcut
+:: Add start menu shortcut
 %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "$s=(New-Object -COM WScript.Shell).CreateShortcut('%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs\mpv.lnk');$s.TargetPath='%mpv_path%';$s.Save()"
 
 echo.

--- a/mpv-root/installer/mpv-install.bat
+++ b/mpv-root/installer/mpv-install.bat
@@ -174,6 +174,9 @@ call :add_type ""                                 "audio" "CUE Sheet"           
 :: Register "Default Programs" entry
 call :reg add "HKLM\SOFTWARE\RegisteredApplications" /v "mpv" /d "SOFTWARE\Clients\Media\mpv\Capabilities" /f
 
+:: Add mpv start menu shortcut
+%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "$s=(New-Object -COM WScript.Shell).CreateShortcut('%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs\mpv.lnk');$s.TargetPath='%mpv_path%';$s.Save()"
+
 echo.
 echo Installed successfully^^! You can now configure mpv's file associations in the
 echo Default Programs control panel.

--- a/mpv-root/installer/mpv-uninstall.bat
+++ b/mpv-root/installer/mpv-uninstall.bat
@@ -55,6 +55,9 @@ for /f "usebackq eol= delims=" %%k in (`reg query "%classes_root_key%" /f "io.mp
 	)
 )
 
+:: Delete start menu shortcut
+del "%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs\mpv.lnk"
+
 echo Uninstalled successfully
 if [%unattended%] == [yes] exit 0
 pause


### PR DESCRIPTION
Adds a start menu shortcut.
Relies on PowerShell because symlinks are unreliable and not in line with other applications.
Uses path to PowerShell to negate errors with "unrecognized command"..