### PR TITLE
Use youtube-dl 's own update mechanism

### DIFF
--- a/mpv-root/installer/updater.ps1
+++ b/mpv-root/installer/updater.ps1
@@ -204,18 +204,8 @@ function Upgrade-Mpv {
 }
 
 function Upgrade-Youtubedl {
-    $need_download = $false
-    $latest_release = Get-Latest-Youtubedl
-
     if (Check-Youtubedl) {
-        if ((.\youtube-dl --version) -match ($latest_release)) {
-            Write-Host "You are already using latest youtube-dl -- $latest_release" -ForegroundColor Green
-            $need_download = $false
-        }
-        else {
-            Write-Host "Newer youtube-dl build available" -ForegroundColor Green
-            $need_download = $true
-        }
+        .\youtube-dl --update
     }
     else {
         Write-Host "youtube-dl doesn't exist. " -ForegroundColor Green -NoNewline
@@ -223,15 +213,9 @@ function Upgrade-Youtubedl {
         Write-Host ""
 
         if ($result -eq 'Y') {
-            $need_download = $true
+            $latest_release = Get-Latest-Youtubedl
+            Download-Youtubedl $latest_release
         }
-        else {
-            $need_download = $false
-        }
-    }
-
-    if ($need_download) {
-        Download-Youtubedl $latest_release
     }
 }
 


### PR DESCRIPTION
Using youtube-dl's '-U / --update' switch has 2 advantages:

1. Slightly reduces the complexity of the script
2. Allows us to use youtube-dl forks like yt-dlp/yt-dlp, in place of the
OG and have it symlinked as youtube-dl.

In that case the updater script will correctly call the update function
for that youtube-dl binary.