### PR TITLE
Don't ask if ffmpeg is needed when it already exists

### DIFF
--- a/mpv-root/installer/updater.ps1
+++ b/mpv-root/installer/updater.ps1
@@ -276,6 +276,9 @@ function Check-GetFFmpeg() {
     $file = "settings.xml"
 
     if (-not (Test-Path $file)) { exit }
+    if (Test-Path "ffmpeg.exe") {
+        return "true"
+    }
     [xml]$doc = Get-Content $file
     if ($doc.settings.getffmpeg -eq "unset") {
         Write-Host "FFmpeg doesn't exist. " -ForegroundColor Green -NoNewline


### PR DESCRIPTION
Before this PR, if I already have (self-downloaded) ffmpeg in the directory, it still says ffmpeg doesn't exist and asks if I need to download it. This PR fixes it, now it will simply upgrade ffmpeg for me.