### PR TITLE
Added $stream.Close() to Get-Arch() function

### DIFF
--- a/mpv-root/installer/updater.ps1
+++ b/mpv-root/installer/updater.ps1
@@ -172,6 +172,7 @@ function Get-Arch {
         0x8664 { $result.FileType = 'x86_64' } # 64bit
     }
 
+    $stream.Close()
     $result
 }
 


### PR DESCRIPTION
Filestream was not closed properly in the Get-Arch() function within updater.ps1, causing mpv.exe to fail to replace when running the updater script.