### PR TITLE
Run script using Windows Powershell v7.x if available

### DIFF
--- a/mpv-root/updater.bat
+++ b/mpv-root/updater.bat
@@ -6,7 +6,16 @@ if exist "%~dp0\installer\updater.ps1" (
 ) else (
     set updater_script="%~dp0\updater.ps1"
 )
-powershell -noprofile -nologo -executionpolicy bypass -File %updater_script%
+
+:: Check if pwsh is in the system's PATH
+where pwsh >nul 2>nul
+if %errorlevel% equ 0 (
+    :: pwsh is in PATH, so run the script using Windows Powershell
+    pwsh -NoProfile -NoLogo -ExecutionPolicy Bypass -File %updater_script%
+) else (
+    :: pwsh is not in PATH, run the script using PowerShell Core
+    powershell -NoProfile -NoLogo -ExecutionPolicy Bypass -File %updater_script%
+)
 
 :: After update, updater.ps1 should not in same folder as mpv.exe
 if exist "%~dp0\installer\updater.ps1" if exist "%~dp0\updater.ps1" (


### PR DESCRIPTION
Currently, updater.bat executes the updater.ps1 script using the older unmaintained Powershell Core even if Windows Powershell 7.x is present. This came to my attention since the updater.ps1 outputs the Powershell version which i noticed has always been v5 even though i have Windows  Powershell v7.x installed. This change executes the updater.ps1 using latest Windows Powershell v7.x if its found in the PATH else fallback to Powershell Core v5.x