### PR TITLE
Fix UserAgent parameter not getting evaluated

### DIFF
--- a/mpv-root/installer/updater.ps1
+++ b/mpv-root/installer/updater.ps1
@@ -21,7 +21,7 @@ function Check-7z {
         $null = New-Item -ItemType Directory -Force (Split-Path $fallback7z)
         $download_file = $fallback7z
         Write-Host "Downloading 7zr.exe" -ForegroundColor Green
-        Invoke-WebRequest -Uri "https://www.7-zip.org/a/7zr.exe" -UserAgent [Microsoft.PowerShell.Commands.PSUserAgent]::FireFox -OutFile $download_file
+        Invoke-WebRequest -Uri "https://www.7-zip.org/a/7zr.exe" -UserAgent $([Microsoft.PowerShell.Commands.PSUserAgent]::FireFox) -OutFile $download_file
     }
     else
     {
@@ -69,7 +69,7 @@ function Check-Mpv {
 
 function Download-Archive ($filename, $link) {
     Write-Host "Downloading" $filename -ForegroundColor Green
-    Invoke-WebRequest -Uri $link -UserAgent [Microsoft.PowerShell.Commands.PSUserAgent]::FireFox -OutFile $filename
+    Invoke-WebRequest -Uri $link -UserAgent $([Microsoft.PowerShell.Commands.PSUserAgent]::FireFox) -OutFile $filename
 }
 
 function Download-Ytplugin ($plugin, $version) {
@@ -91,7 +91,7 @@ function Download-Ytplugin ($plugin, $version) {
             $plugin_exe = "youtube-dl.exe"
         }
     }
-    Invoke-WebRequest -Uri $link -UserAgent [Microsoft.PowerShell.Commands.PSUserAgent]::FireFox -OutFile $plugin_exe
+    Invoke-WebRequest -Uri $link -UserAgent $([Microsoft.PowerShell.Commands.PSUserAgent]::FireFox) -OutFile $plugin_exe
 }
 
 function Extract-Archive ($file) {


### PR DESCRIPTION
The Invoke-WebRequest cmdlet expects a string as its -UserAgent Parameter. Currently the script instead passes a command which is not getting evaluated and instead passed as a literal string. This didn't cause problems with Powershell Core ( v5) but Windows Powershell ( v7) requires it to be passed correctly for the script to execute properly. This commit fixes that